### PR TITLE
fix: dynamically import `execa` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "type": "module",
   "packageManager": "pnpm@8.15.0",
   "dependencies": {
-    "execa": "^8.0.1"
+    "execa": "^8.0.1",
+    "p-safe": "^0.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   execa:
     specifier: ^8.0.1
     version: 8.0.1
+  p-safe:
+    specifier: ^0.1.0
+    version: 0.1.0
 
 devDependencies:
   '@types/chai':
@@ -1580,6 +1583,10 @@ packages:
     dependencies:
       p-limit: 3.1.0
     dev: true
+
+  /p-safe@0.1.0:
+    resolution: {integrity: sha512-A3YWGGaKK++7P6zYbT6UeQOKrsmUVv8ypLTsKOPdBTEK7T7+yzJSjeiwreVPa9eH1XfRu+dvacvde5w7UslNcw==}
+    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,8 @@
+export class ShellError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode: number) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}

--- a/src/ip/route.ts
+++ b/src/ip/route.ts
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa';
+import { execShell } from '@/utils/exec-shell';
 
 interface RoutingTableEntry {
   destination: string; // e.g., "default" or "192.168.1.0/24"
@@ -11,9 +11,12 @@ interface RoutingTableEntry {
 }
 
 export async function list() {
-  const { stdout } = await execaCommand('ip route list');
+  const { error, data } = await execShell(['ip', 'route', 'list']);
+  if (error) {
+    throw error;
+  }
 
-  const lines = stdout.split('\n');
+  const lines = data.output.split('\n');
   const routes: RoutingTableEntry[] = [];
 
   for (const line of lines) {

--- a/src/utils/exec-shell.ts
+++ b/src/utils/exec-shell.ts
@@ -1,0 +1,31 @@
+import { trySafe } from 'p-safe';
+import { ShellError } from '@/errors';
+
+export async function execShell(cmd: string[]) {
+  return trySafe<ShellResult, ShellError>(async () => {
+    const { execa } = await import('execa');
+
+    const res = await execa(cmd.join(' '), {
+      shell: true,
+    });
+
+    const success = res.exitCode === 0;
+    const [stdout, stderr] = [res.stdout, res.stderr].map((s) => s.trim());
+
+    if (success || (stdout && stdout !== '')) {
+      return {
+        data: {
+          output: stdout,
+          exitCode: res.exitCode,
+        },
+      };
+    }
+
+    return { error: new ShellError(stderr, res.exitCode) };
+  });
+}
+
+export interface ShellResult {
+  output: string;
+  exitCode: number;
+}


### PR DESCRIPTION
Some features of this module use Node.js modules, which makes the features that are pure JavaScript entirely useless.

The hope is to dynamically import the `execa` module to prevent importing modules that are not available in environments such as the browser.